### PR TITLE
Features/auto host block

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,19 @@ optional arguments:
   --tc TC TC            Poll for hosts with threat and certainty scores >=, eg --tc 50 50  
   --tag TAG             Host Tag for pulling context from SentinelOne  
   --blocktag BLOCKTAG  
-  --unblocktag UNBLOCKTAG  
+  --unblocktag UNBLOCKTAG
+  --tcautoblock TC TC            Auto-block S1 agents when threat and certainty minimum scores are reached >=, eg --tcautoblock 90 100
+  --monitormode            Auto-block can be set to "monitoring" mode, which can be used for dry-testing. This will not block any S1-agents.    
   --verbose             Verbose logging
 
+# Additional scripts
+An additional script (s1_sendmail.py) has been provided. This script can be used to send an email notification when one or multiple hosts are blocked.
+This can be used in combination with a cron job script, for example.
 
 ## Authors
 
-* **Matt Pieklik** - *Initial work*
+* **Matt Pieklik (Vectra AI)** - *Initial work*
+* **Jeffrey Jansen (Access42)** - *Small improvements and additional features*
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 s1.py is a python script that provides an API level integration between SentinelOne and Cognito Detect.
 Contextual information is obtained from SentinelOne and applied to a host in the form of tags.  This is triggered manually
 by adding a specified tag to a host, or automatically based on the host's Threat and Certainty scoring.
-Host enforcement (blocking/unblocking) can be triggered by manually adding a specified tag to a host.
+Host enforcement (blocking/unblocking) can be triggered by manually adding a specified tag to a host or automatically by pre-defining a minimum Threat and Certainty scoring threshold.
 
-# Fork extra features
+# Features
 
-- Only SentinelOne tags with a "S1" prefix are appended/removed from the Cognito host. Existing tags are untouched. This allows the use of custom host tags without being overriden. 
+- Only SentinelOne tags with a "S1" prefix are appended/removed from the Cognito host. Existing tags are untouched. This allows the use of custom host tags without being overriden.
+- Auto-blocking of SentinelOne hosts when a pre-defined Threat and Certainty scoring minimum is met by a host.
 
 ## Prerequisites
 
@@ -40,10 +41,10 @@ Edit the config.py file and adjust the required variables according to your envi
 
 When ran, the script needs to supplied one or more parameters.  Examples:
 
-
 ```
 s1 --tag S1_context
 s1 --tag S1_context --tc 75 75
+s1 --tag S1_context --tc 75 75 --tcautoblock 90 100
 ```
 
 The --tag flag will query Detect for active hosts that have the specified tag (S1_context in this example), 
@@ -52,18 +53,29 @@ obtain contextual information from SentinelOne, and apply the contextual informa
 The --tc flag allows a Host's Threat and Certainty scoring thresholds to be supplied for contextual tagging.  Flags can
 be combined.
 
-### Typical Usage
+The --tcautoblock flag allows a Host's Threat and Certainty scoring minimum threshold to perform an auto-block of S1 agent. These values should always be higher than the --tc flag. 
 
+### Usage
+**Example typical usage**
 ```
 s1 --tag S1_context --tc 75 75 --blocktag S1_block --unblocktag S1_unblock
 ```
-Specifying multiple flags allows the integration to cover multiple use cases. 
+Specifying multiple flags allows the integration to cover multiple use cases.
+
+**Example usage when auto-blocking of S1 agent is required**
+ 
+```
+s1 --tag S1_context --tc 75 75 --tcautoblock 90 100 --blocktag S1_block --unblocktag S1_unblock
+```
+
+The Host's Threat and Certainty scoring minimum threshold can be provided. 
 
 ### Recommendations
 
 To test the desired use cases, run the s1.py script from the CLI for testing.  To run in production, the script is
  designed to be called via a cron job.
  
+The auto-blocking of S1 agents should be used with care. The recommendation is not to set the threat/certainty threshold too low, to prevent multiple S1 hosts from being directly blocked by for example false positives detections.    
  
 ## Help Output
 

--- a/s1/s1.py
+++ b/s1/s1.py
@@ -33,7 +33,6 @@ S1_HEADER = {
 # Setup logging
 LOG = logging.getLogger(__name__)
 
-
 def validate_config(func):
     def config_validator():
         if bool(validators.url(COGNITO_BRAIN)):
@@ -56,7 +55,7 @@ def obtain_args():
                         help='Auto block S1 agents if threat and certainty scores >=, eg --tcautoblock 80 100.')
     parser.add_argument('--monitormode', action='store_true', default=False,
                         dest='monitormode',
-                        help='Autoblock can be set to "monitoring" mode, which can be used for dry-testing. This will not block any S1-agents.')
+                        help='Auto-block of S1 agents can be set to "monitoring" mode, which can be used for dry-testing. This will not block any S1-agents.')
     parser.add_argument('--tag', type=str, nargs=1, default=False, help='Host Tag for pulling context from SentinelOne')
     parser.add_argument('--blocktag', type=str, nargs=1, default=False)
     parser.add_argument('--unblocktag', type=str, nargs=1, default=False)
@@ -157,7 +156,7 @@ def add_host_note(hostid, note):
     VC.set_host_note(host_id=hostid, note=log_event, append=True)
 
 def auto_block_s1_agents(hosts, tc_autoblock, blocktags, monitor_mode_enabled):
-    # Supplied hosts will be auto-blocked, if TC autoblock criteria are met.
+    # Supplied hosts will be auto-blocked, if TC auto-block criteria are met.
     hosts_blocked = []
 
     for hostid in hosts.keys():
@@ -174,9 +173,9 @@ def auto_block_s1_agents(hosts, tc_autoblock, blocktags, monitor_mode_enabled):
                 print('hosts_id:{} already auto-blocked and skipped'.format(host_ip_address))
             else:
                 if monitor_mode_enabled:
-                    print('Auto-blocking S1 agent {} - threat/certainty [{}/{}] => autoblock [{}/{}] - monitor mode enabled!'.format(host_ip_address, host_threat, host_certainty, host_threat_minimum, host_certainty_minimum))
+                    print('Auto-blocking S1 agent {} - threat/certainty [{}/{}] => auto-block [{}/{}] - monitor mode enabled!'.format(host_ip_address, host_threat, host_certainty, host_threat_minimum, host_certainty_minimum))
                 else:
-                    add_host_note(hostid, 'Auto-blocking S1 agent {} - threat/certainty [{}/{}] => autoblock [{}/{}]'.format(host_ip_address, host_threat, host_certainty, host_threat_minimum, host_certainty_minimum))
+                    add_host_note(hostid, 'Auto-blocking S1 agent {} - threat/certainty [{}/{}] => auto-block [{}/{}]'.format(host_ip_address, host_threat, host_certainty, host_threat_minimum, host_certainty_minimum))
                     VC.set_host_tags(host_id=hostid, tags=blocktags, append=True)
                     hosts_blocked.append(hosts[hostid])
 

--- a/s1/s1_sendmail.py
+++ b/s1/s1_sendmail.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+import s1
+import smtplib, ssl
+from config import COGNITO_BRAIN, S1_URL
+
+# This SMTP-configuration should be adjusted to your needs.
+smtp_host = "127.0.0.1"
+smtp_port = 25
+smtp_from = "user@localhost.localdomain"
+smtp_to = "user@localhost"
+smtp_message_template = """Hello,
+
+This is an automated message. 
+
+One or more SentinelOne agents have been automatically blocked, because the hosts exceed the auto-block Threat and Certainty 
+minimum threshold. 
+
+Amount of blocked S1 agents: {}
+
+The following hosts were blocked:
+{}
+
+Vectra URL: {}
+SentinelOne URL: {}
+
+Thank you.
+"""
+
+def send_mail(hosts_blocked):
+    message_content = ""
+
+    for host in hosts_blocked:
+        host_ip_address = host['last_source']
+        host_name = host['name']
+
+        message_content += "- " + host_ip_address
+        message_content += " - host [" + host_name + "]"
+        message_content += " - threat/certainty [{}/{}] ".format(host['threat'], host['certainty'])
+        message_content += " - severity [{}] ".format(host['severity'])
+        message_content += " - URL [{}] ".format(host['host_url'])
+        message_content += "\n"
+
+    #context = ssl._create_unverified_context()
+    server = smtplib.SMTP(smtp_host, smtp_port)
+    server.ehlo()
+    #server.starttls(context)
+    server.sendmail(smtp_from, smtp_to, smtp_message_template.format(str(len(hosts_blocked)),
+                                                                     message_content,
+                                                                     COGNITO_BRAIN,
+                                                                     S1_URL))
+    print('Sending email notification to {} for {} blocked hosts'.format(smtp_to, str(len(hosts_blocked))))
+
+# Monkey patching s1.py.
+# This custom impl. will send an email using Sendmail to inform about blocked hosts.
+def auto_block_s1_agents_sendmail(hosts, tc_autoblock, blocktags, monitor_mode_enabled):
+    # Supplied hosts will be auto-blocked, if TC autoblock criteria are met.
+    hosts_blocked = []
+
+    for hostid in hosts.keys():
+        host_ip_address = hosts[hostid]['last_source']
+        host_threat = hosts[hostid]['threat']
+        host_certainty = hosts[hostid]['certainty']
+
+        host_threat_minimum = tc_autoblock[0]
+        host_certainty_minimum = tc_autoblock[1]
+
+        if host_threat >= host_threat_minimum and host_certainty >= host_certainty_minimum:
+            # We consider the host as already blocked, when it has the provided BLOCKTAG as host tag.
+            if blocktags[0] in hosts[hostid]['tags']:
+                print('hosts_id:{} already auto-blocked and skipped'.format(host_ip_address))
+            else:
+               s1.add_host_note(hostid, 'Auto-blocking S1 agent {} - threat/certainty [{}/{}] => auto-block [{}/{}]'.format(host_ip_address, host_threat, host_certainty, host_threat_minimum, host_certainty_minimum))
+               s1.VC.set_host_tags(host_id=hostid, tags=blocktags, append=True)
+               hosts_blocked.append(hosts[hostid])
+
+    # Send email for blocked hosts..
+    if len(hosts_blocked) > 0:
+        send_mail(hosts_blocked)
+
+    return hosts_blocked
+
+# Override original method with our custom impl.
+s1.auto_block_s1_agents = auto_block_s1_agents_sendmail
+
+if __name__ == '__main__':
+    s1.main()


### PR DESCRIPTION
Implemented monitor-mode flag as argument for dry-testing of auto-blocking mode.
Prevented Vectra hosts of being re-autoblocked again, if they are already blocked.
README.md is adjusted to be in line with the additional implemented features.
Added an additional Python script (s1_sendmail.py) to send email notifications when hosts are automatically blocked.